### PR TITLE
Refactor Packet reading to be more pluggable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "env_filter"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +230,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures-core"
@@ -347,6 +359,32 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -551,6 +589,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +641,7 @@ dependencies = [
  "env_logger",
  "etherparse",
  "log",
+ "mockall",
  "nom",
  "openssl",
  "pnet",
@@ -695,6 +760,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ clap = { version = "4.5.11", features = ["derive"] }
 env_logger = "0.11.5"
 anyhow = "1.0.86"
 
+[dev-dependencies]
+mockall = "0.13"

--- a/src/live_packet_reader.rs
+++ b/src/live_packet_reader.rs
@@ -1,0 +1,80 @@
+use anyhow::Result;
+use pnet::datalink::{self, Channel::Ethernet};
+
+use crate::tun::PacketReader;
+
+pub struct LivePacketReader<'a> {
+    rx: Box<dyn pnet::datalink::DataLinkReceiver + 'a>,
+}
+
+impl<'a> LivePacketReader<'a> {
+    pub fn new(interface_name: &str) -> Result<Self> {
+        let interfaces = datalink::interfaces();
+        let interface = interfaces
+            .into_iter()
+            .find(|iface| iface.name == interface_name)
+            .ok_or_else(|| anyhow::anyhow!("Device not found"))?;
+
+        let (_, rx) = match datalink::channel(&interface, Default::default())? {
+            Ethernet(_, rx) => ((), rx),
+            _ => return Err(anyhow::anyhow!("Unhandled channel type")),
+        };
+
+        Ok(Self { rx })
+    }
+}
+
+impl<'a> PacketReader for LivePacketReader<'a> {
+    fn read_packet(&mut self) -> Option<Vec<u8>> {
+        match self.rx.next() {
+            Ok(packet) => Some(packet.to_vec()),
+            Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    // Mock the pnet::datalink::DataLinkReceiver trait
+    struct MockDataLinkReceiver {
+        packets: Vec<Vec<u8>>,
+        current_packet: Option<Vec<u8>>,
+    }
+
+    impl pnet::datalink::DataLinkReceiver for MockDataLinkReceiver {
+        fn next(&mut self) -> io::Result<&[u8]> {
+            if let Some(packet) = self.packets.pop() {
+                self.current_packet = Some(packet);
+                Ok(self.current_packet.as_deref().unwrap())
+            } else {
+                Err(io::Error::new(io::ErrorKind::WouldBlock, "No more packets"))
+            }
+        }
+    }
+
+    #[test]
+    fn test_read_packet() {
+        // Set up the mock data link receiver
+        let mock_packets = vec![
+            vec![0x01, 0x02, 0x03],
+            vec![0x04, 0x05, 0x06],
+            vec![0x07, 0x08, 0x09],
+        ];
+        let mock_receiver = MockDataLinkReceiver {
+            packets: mock_packets,
+            current_packet: None,
+        };
+
+        let mut packet_reader = LivePacketReader {
+            rx: Box::new(mock_receiver),
+        };
+
+        assert_eq!(packet_reader.read_packet(), Some(vec![0x07, 0x08, 0x09]));
+        assert_eq!(packet_reader.read_packet(), Some(vec![0x04, 0x05, 0x06]));
+        assert_eq!(packet_reader.read_packet(), Some(vec![0x01, 0x02, 0x03]));
+        assert_eq!(packet_reader.read_packet(), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
+mod live_packet_reader;
 mod redis;
 mod tun;
 
 use clap::Parser;
 use env_logger;
+use live_packet_reader::LivePacketReader;
 use redis::RespHandler;
 use std::io;
 use std::sync::Arc;
@@ -28,10 +30,12 @@ async fn main() -> io::Result<()> {
     let args = Args::parse();
 
     let handler = Arc::new(Mutex::new(RespHandler::new(args.redis_port)));
+    let active_packet_reader =
+        LivePacketReader::new(&args.interface).expect("Failed to create packet reader");
     let observer = Observer::new();
 
     observer
-        .capture_packets(&args.interface, handler)
+        .capture_packets(active_packet_reader, handler)
         .await
         .unwrap();
 


### PR DESCRIPTION
The capture_packets function now takes a changeable packet_reader implementation to run its algorithms on. This lets us play around with the packet reader by giving a pcaps reader that potentially can observe by simply playing back pcaps files.