### PR TITLE
RESP Parser now separates command, key & val

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,15 +199,6 @@ dependencies = [
  "env_filter",
  "humantime",
  "log",
-]
-
-[[package]]
-name = "etherparse"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095ab548cf452be5813424558a18af88f0a620d0f4a3d8793aa09311a3b6fa5f"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -639,7 +624,6 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
- "etherparse",
  "log",
  "mockall",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 tokio = { version = "1.39.2", features = ["full"] }
 pnet = "0.35"
-etherparse = "0.14.3"
 nom = "7.1"
 openssl = "0.10"
 tokio-openssl = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,13 @@ async fn main() -> io::Result<()> {
 
     let args = Args::parse();
 
-    let handler = Arc::new(Mutex::new(RespHandler::new(args.redis_port)));
+    let redis_handler = Arc::new(Mutex::new(RespHandler::new(args.redis_port)));
     let active_packet_reader =
         LivePacketReader::new(&args.interface).expect("Failed to create packet reader");
     let observer = Observer::new();
 
     observer
-        .capture_packets(active_packet_reader, handler)
+        .capture_packets(active_packet_reader, redis_handler)
         .await
         .unwrap();
 

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,6 +1,6 @@
-use crate::tun::{Handler, Metrics};
 use anyhow::Result;
 use nom::{
+    branch::alt,
     bytes::complete::{tag, take, take_while},
     character::complete::char,
     IResult,
@@ -8,32 +8,28 @@ use nom::{
 use std::{collections::HashMap, str, sync::Arc};
 use tokio::sync::Mutex;
 
-// TODO: Try to split key and value.
-#[derive(Debug, PartialEq)]
-pub enum RespValue {
-    SimpleString(String),
-    Error(String),
-    Integer(i64),
-    BulkString(Option<String>),
-    Array(Vec<RespValue>),
+use crate::tun::{Handler, Metrics};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RespValue {
+    pub command: Option<String>,
+    pub key: Option<String>,
+    pub value: Option<String>,
 }
 
 impl RespValue {
     pub fn to_string(&self) -> String {
-        match self {
-            RespValue::SimpleString(s) => format!("+{}", s),
-            RespValue::Error(s) => format!("-{}", s),
-            RespValue::Integer(i) => format!(":{}", i),
-            RespValue::BulkString(Some(s)) => format!("{}", s),
-            RespValue::BulkString(None) => "$-1\r\n".to_string(),
-            RespValue::Array(values) => {
-                let mut s = format!("");
-                for value in values {
-                    s.push_str(&value.to_string());
-                }
-                s
-            }
+        let mut s = String::new();
+        if let Some(ref command) = self.command {
+            s.push_str(&format!("Command: {}\n", command));
         }
+        if let Some(ref key) = self.key {
+            s.push_str(&format!("Key: {}\n", key));
+        }
+        if let Some(ref value) = self.value {
+            s.push_str(&format!("Value: {}\n", value));
+        }
+        s
     }
 }
 
@@ -41,31 +37,52 @@ fn is_digit(c: u8) -> bool {
     c.is_ascii_digit()
 }
 
-pub fn parse_simple_string(input: &[u8]) -> IResult<&[u8], RespValue> {
+fn parse_simple_string(input: &[u8]) -> IResult<&[u8], RespValue> {
     let (input, _) = char('+')(input)?;
     let (input, s) = take_while(|c| c != b'\r')(input)?;
     let (input, _) = tag("\r\n")(input)?;
-    let s = str::from_utf8(s).unwrap().to_string();
-    Ok((input, RespValue::SimpleString(s)))
+    let command = str::from_utf8(s).unwrap().to_string();
+    Ok((
+        input,
+        RespValue {
+            command: Some(command),
+            key: None,
+            value: None,
+        },
+    ))
 }
 
-pub fn parse_error(input: &[u8]) -> IResult<&[u8], RespValue> {
+fn parse_error(input: &[u8]) -> IResult<&[u8], RespValue> {
     let (input, _) = char('-')(input)?;
     let (input, s) = take_while(|c| c != b'\r')(input)?;
     let (input, _) = tag("\r\n")(input)?;
-    let s = str::from_utf8(s).unwrap().to_string();
-    Ok((input, RespValue::Error(s)))
+    let command = str::from_utf8(s).unwrap().to_string();
+    Ok((
+        input,
+        RespValue {
+            command: Some(command),
+            key: None,
+            value: None,
+        },
+    ))
 }
 
-pub fn parse_integer(input: &[u8]) -> IResult<&[u8], RespValue> {
+fn parse_integer(input: &[u8]) -> IResult<&[u8], RespValue> {
     let (input, _) = char(':')(input)?;
     let (input, s) = take_while(is_digit)(input)?;
     let (input, _) = tag("\r\n")(input)?;
-    let s = str::from_utf8(s).unwrap().parse().unwrap();
-    Ok((input, RespValue::Integer(s)))
+    let value = str::from_utf8(s).unwrap().to_string();
+    Ok((
+        input,
+        RespValue {
+            command: None,
+            key: None,
+            value: Some(value),
+        },
+    ))
 }
 
-pub fn parse_bulk_string(input: &[u8]) -> IResult<&[u8], RespValue> {
+fn parse_bulk_string(input: &[u8]) -> IResult<&[u8], RespValue> {
     let (input, _) = char('$')(input)?;
     let (input, length_str) = take_while(is_digit)(input)?;
     let length = str::from_utf8(length_str)
@@ -75,15 +92,23 @@ pub fn parse_bulk_string(input: &[u8]) -> IResult<&[u8], RespValue> {
     let (input, _) = tag("\r\n")(input)?;
     let (input, data) = take(length)(input)?;
     let (input, _) = tag("\r\n")(input)?;
-    let s = if data.is_empty() {
+    let value = if data.is_empty() {
         None
     } else {
         Some(str::from_utf8(data).unwrap().to_string())
     };
-    Ok((input, RespValue::BulkString(s)))
+
+    Ok((
+        input,
+        RespValue {
+            command: None,
+            key: None,
+            value,
+        },
+    ))
 }
 
-pub fn parse_array(input: &[u8]) -> IResult<&[u8], RespValue> {
+fn parse_array(input: &[u8]) -> IResult<&[u8], RespValue> {
     let (input, _) = char('*')(input)?;
     let (input, length_str) = take_while(is_digit)(input)?;
     let length = str::from_utf8(length_str)
@@ -91,21 +116,32 @@ pub fn parse_array(input: &[u8]) -> IResult<&[u8], RespValue> {
         .parse::<usize>()
         .unwrap();
     let (input, _) = tag("\r\n")(input)?;
-    let mut values = Vec::with_capacity(length);
     let mut input = input;
 
+    let mut values = Vec::with_capacity(length);
     for _ in 0..length {
         let (new_input, value) = parse_resp(input)?;
         input = new_input;
         values.push(value);
     }
 
-    Ok((input, RespValue::Array(values)))
+    let command = values.get(0).and_then(|v| v.value.clone());
+    let key = values.get(1).and_then(|v| v.value.clone());
+    let value = values.get(2).and_then(|v| v.value.clone());
+
+    Ok((
+        input,
+        RespValue {
+            command,
+            key,
+            value,
+        },
+    ))
 }
 
 // General RESP parser that chooses the correct type
 pub fn parse_resp(input: &[u8]) -> IResult<&[u8], RespValue> {
-    nom::branch::alt((
+    alt((
         parse_simple_string,
         parse_error,
         parse_integer,
@@ -114,9 +150,92 @@ pub fn parse_resp(input: &[u8]) -> IResult<&[u8], RespValue> {
     ))(input)
 }
 
+// Unit Tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_string() {
+        let input = b"+OK\r\n";
+        let expected = RespValue {
+            command: Some("OK".to_string()),
+            key: None,
+            value: None,
+        };
+        assert_eq!(parse_simple_string(input).unwrap().1, expected);
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let input = b"-Error message\r\n";
+        let expected = RespValue {
+            command: Some("Error message".to_string()),
+            key: None,
+            value: None,
+        };
+        assert_eq!(parse_error(input).unwrap().1, expected);
+    }
+
+    #[test]
+    fn test_parse_integer() {
+        let input = b":1000\r\n";
+        let expected = RespValue {
+            command: None,
+            key: None,
+            value: Some("1000".to_string()),
+        };
+        assert_eq!(parse_integer(input).unwrap().1, expected);
+    }
+
+    #[test]
+    fn test_parse_bulk_string() {
+        let input = b"$6\r\nfoobar\r\n";
+        let expected = RespValue {
+            command: None,
+            key: None,
+            value: Some("foobar".to_string()),
+        };
+        assert_eq!(parse_bulk_string(input).unwrap().1, expected);
+    }
+
+    #[test]
+    fn test_parse_bulk_string_none() {
+        let input = b"$0\r\n\r\n";
+        let expected = RespValue {
+            command: None,
+            key: None,
+            value: None,
+        };
+        assert_eq!(parse_bulk_string(input).unwrap().1, expected);
+    }
+
+    #[test]
+    fn test_parse_array() {
+        let input = b"*3\r\n$4\r\nECHO\r\n$3\r\nkey\r\n$5\r\nvalue\r\n";
+        let expected = RespValue {
+            command: Some("ECHO".to_string()),
+            key: Some("key".to_string()),
+            value: Some("value".to_string()),
+        };
+        assert_eq!(parse_array(input).unwrap().1, expected);
+    }
+
+    //#[test]
+    //fn test_parse_array_mixed() {
+    //    let input = b"*4\r\n$4\r\nECHO\r\n$3\r\nkey\r\n$5\r\nvalue\r\n$4\r\nTEST\r\n";
+    //    let expected = RespValue {
+    //        command: Some("ECHO".to_string()),
+    //        key: Some("key".to_string()),
+    //        value: Some("value".to_string()),
+    //    };
+    //    assert_eq!(parse_array(input).unwrap().1, expected);
+    //}
+}
+
 pub struct RespHandler {
     port: u16,
-    key_map: Arc<Mutex<HashMap<u32, String>>>,
+    key_map: Arc<Mutex<HashMap<u32, RespValue>>>,
 }
 
 impl RespHandler {
@@ -146,85 +265,32 @@ impl Handler<RespValue> for RespHandler {
         // We already know that metrics is not None
         let metrics = metrics.unwrap();
 
-        let string_key = input.to_string();
         let mut store = self.key_map.lock().await;
         if !store.contains_key(&metrics.identifier) {
             // Check if the identifier exists and save it in the store
-            store.insert(metrics.identifier, string_key.clone());
+            store.insert(metrics.identifier, input.clone());
         }
 
         if let Some(latency) = metrics.latency {
+            let status = if input.to_string().contains("ERR") {
+                "ERR"
+            } else {
+                "OK"
+            };
             // Print the latency and the key
+            let stored_value = store
+                .get(&metrics.identifier)
+                .ok_or_else(|| anyhow::anyhow!("Failed to get value from store"))?;
             println!(
-                "Key: {}, Latency: {}ms",
-                store.get(&metrics.identifier).unwrap(),
+                "Key: {}, Latency: {}ms, Status: {}",
+                stored_value.key.as_ref().unwrap(),
                 latency.as_millis(),
+                status,
             );
             // clean up the store
             store.remove(&metrics.identifier);
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_simple_string() {
-        let data = b"+OK\r\n";
-        assert_eq!(
-            parse_simple_string(data),
-            Ok((&b""[..], RespValue::SimpleString("OK".to_string())))
-        );
-    }
-
-    #[test]
-    fn test_parse_error() {
-        let data = b"-Error message\r\n";
-        assert_eq!(
-            parse_error(data),
-            Ok((&b""[..], RespValue::Error("Error message".to_string())))
-        );
-    }
-
-    #[test]
-    fn test_parse_integer() {
-        let data = b":12345\r\n";
-        assert_eq!(
-            parse_integer(data),
-            Ok((&b""[..], RespValue::Integer(12345)))
-        );
-    }
-
-    #[test]
-    fn test_parse_bulk_string() {
-        let data = b"$6\r\nfoobar\r\n";
-        assert_eq!(
-            parse_bulk_string(data),
-            Ok((&b""[..], RespValue::BulkString(Some("foobar".to_string()))))
-        );
-    }
-
-    #[test]
-    fn test_parse_array() {
-        let data = b"*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n";
-        let expected = RespValue::Array(vec![
-            RespValue::BulkString(Some("foo".to_string())),
-            RespValue::BulkString(Some("bar".to_string())),
-        ]);
-        assert_eq!(parse_array(data), Ok((&b""[..], expected)));
-    }
-
-    #[test]
-    fn test_parse_resp() {
-        let data = b"*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n";
-        let expected = RespValue::Array(vec![
-            RespValue::BulkString(Some("foo".to_string())),
-            RespValue::BulkString(Some("bar".to_string())),
-        ]);
-        assert_eq!(parse_resp(data), Ok((&b""[..], expected)));
     }
 }

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -51,7 +51,8 @@ impl Observer {
                 // Ideally we should be using the timestamp from the packet header/kernel.
                 // But this isnt easy enough. One way to do this is to set SO_TIMESTAMP on the socket
                 // and then read the timestamp from the packet header. For the purpose of the
-                // POC and simplicity, we are using this method temporarily.
+                // POC and simplicity, we are using this method temporarily. Moreover, this also
+                // doesn't work if we are playing back a pcap file.
                 let timestamp = Instant::now();
                 if let Some(ethernet_packet) = EthernetPacket::new(&packet) {
                     if ethernet_packet.get_ethertype() == EtherTypes::Ipv4 {


### PR DESCRIPTION
The nom based RESP Parser now is able to extract Command, Key, Value into the RespValue struct it uses. This is still a hacky solution and not very very robust for now. But this solves the current requirement of simply deriving Redis requests simply from observing ip packets.